### PR TITLE
Update argonaut dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,9 +15,9 @@
     ],
     "dependencies": {
         "purescript-aff": "^v5.1.2",
-        "purescript-argonaut": "^v6.0.0",
+        "purescript-argonaut": "^v7.0.0",
         "purescript-biscotti-cookie": "^v0.2.0",
-        "purescript-biscotti-session": "^v0.1.1",
+        "purescript-biscotti-session": "^v0.1.2",
         "purescript-effect": "^v2.0.1",
         "purescript-either": "^v4.1.1",
         "purescript-generics-rep": "^v6.1.1",


### PR DESCRIPTION
This PR builds on the argonaut upgrade for [biscotti-session](https://github.com/drewolson/purescript-biscotti-session). Fortunately this library builds with either version of that library and Argonaut, so this isn't necessary to merge in order to be compatible with the next package set. However, it will still need a new release to work for Bower users.